### PR TITLE
Large timestamps are treated as absolute values

### DIFF
--- a/osc.js
+++ b/osc.js
@@ -59,11 +59,16 @@ module.exports = function(RED) {
                 } else if (typeof msg.payload === 'object' && msg.payload.packets) {
                     // If we receive a bundle
                     packet = msg.payload;
-                    packet.timeTag = osc.timeTag(msg.payload.timeTag);
+		    // For very large timeTags treat them as absolute timestamps
+		    // rather than offsets from now()
+		    if (msg.payload.timeTag > 10000000) {
+			packet.timeTag = osc.timeTag(0, msg.payload.timeTag);
+		    } else {
+			packet.timeTag = osc.timeTag(msg.payload.timeTag);
+		    }
                 } else {
                     packet = {address: msg.topic, args: msg.payload};
                 }
-
                 msg.payload = new Buffer(osc.writePacket(packet));
             }
             node.send(msg);


### PR DESCRIPTION
I have been using node-red-contrib-osc for sending messages to SuperCollider, developing some new nodes for music synthesis. This usually works fine locally, but over a large flow jitter occurs because of variation in time spent for messages to traverse the flow. This is particularly problematic for the project I'm working on, with a network of RPis using node-red for collaborative music making. 

OSC bundles can fix this, but this only works properly with absolute times in the future, rather than relative times, as there is variation in the  time taken from the original message being created to it being sent via OSC. There is an option in the node OSC module to specify absolute timestamps, but this is not accessible through node-red-contrib-osc. The requested change allows this to happen by assuming that very large timestamps (>10000000 = 2.78 hours) refer to absolute times (i.e. offset since 1st Jan 1970) rather than relative to now().
I'd be happy to have a larger constant for comparison if you would like to, but I couldn't think of any application that might have bundles more than 2 hours into the future. Anything smaller  than 1497358330727 (which is now() today) would be fine for a cutoff.

If accepted, ideally the new version should also be submitted to npm so that I can install node-red-contrib-osc as a dependency either with npm directly or through the node-red interface.

Thanks