### PR TITLE
Lock osc to 2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "node-red"
     ],
     "dependencies": {
-        "osc": "^2.2.3"
+        "osc": "2.2.3"
     },
     "node-red": {
         "nodes": {


### PR DESCRIPTION
This fixes https://github.com/njh/node-red-contrib-osc/issues/22