### PR TITLE
Allow OSC receive parser to work with TCP packets

### DIFF
--- a/osc.html
+++ b/osc.html
@@ -25,11 +25,6 @@
         Include metadata
     </div>
     <div class="form-row">
-        <label>TCP</label>
-        <input type="checkbox" id="node-input-tcp" style="display: inline-block; width: auto; vertical-align: top;">
-        Process received packets from TCP
-    </div>
-    <div class="form-row">
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
@@ -70,8 +65,7 @@
         defaults: {
             name: {value:""},
             path: {value:""},
-            metadata: {value: false},
-            tcp: {value: false}
+            metadata: {value: false}
         },
         inputs:1,
         outputs:1,

--- a/osc.html
+++ b/osc.html
@@ -25,6 +25,11 @@
         Include metadata
     </div>
     <div class="form-row">
+        <label>TCP</span></label>
+        <input type="checkbox" id="node-input-tcp" style="display: inline-block; width: auto; vertical-align: top;">
+        Process received packets from TCP
+    </div>
+    <div class="form-row">
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
@@ -65,7 +70,8 @@
         defaults: {
             name: {value:""},
             path: {value:""},
-            metadata: {value: false}
+            metadata: {value: false},
+            tcp: {value: false}
         },
         inputs:1,
         outputs:1,

--- a/osc.html
+++ b/osc.html
@@ -25,7 +25,7 @@
         Include metadata
     </div>
     <div class="form-row">
-        <label>TCP</span></label>
+        <label>TCP</label>
         <input type="checkbox" id="node-input-tcp" style="display: inline-block; width: auto; vertical-align: top;">
         Process received packets from TCP
     </div>

--- a/osc.js
+++ b/osc.js
@@ -28,7 +28,7 @@ module.exports = function(RED) {
         node.decode = function(_msg) {
             if (node.tcp) {
                 // skip length bytes on tcp message
-                _msg.payload.slice(4, _msg.payload.length);
+                _msg.payload = _msg.payload.slice(4, _msg.payload.length);
             }
             _msg.raw = osc.readPacket(_msg.payload, {"metadata": node.metadata, "unpackSingleArgs": true});
             if (_msg.raw.packets) {

--- a/osc.js
+++ b/osc.js
@@ -23,10 +23,9 @@ module.exports = function(RED) {
         var node = this;
         node.path = n.path;
         node.metadata = n.metadata;
-        node.tcp = n.tcp;
 
         node.decode = function(_msg) {
-            if (node.tcp) {
+            if (_msg._session.type.includes("tcp")) {
                 // skip length bytes on tcp message
                 _msg.payload = _msg.payload.slice(4, _msg.payload.length);
             }

--- a/osc.js
+++ b/osc.js
@@ -39,6 +39,8 @@ module.exports = function(RED) {
         node.on("input", function(msg, send, done) {
             // When we get a Buffer
             if (Buffer.isBuffer(msg.payload)) {
+                // skip length bytes on tcp message
+                msg.payload.slice(4, msg.payload.length);
                 msg = node.decode(msg);
             // When we get an Object
             } else {

--- a/osc.js
+++ b/osc.js
@@ -23,8 +23,13 @@ module.exports = function(RED) {
         var node = this;
         node.path = n.path;
         node.metadata = n.metadata;
+        node.tcp = n.tcp;
 
         node.decode = function(_msg) {
+            if (node.tcp) {
+                // skip length bytes on tcp message
+                _msg.payload.slice(4, _msg.payload.length);
+            }
             _msg.raw = osc.readPacket(_msg.payload, {"metadata": node.metadata, "unpackSingleArgs": true});
             if (_msg.raw.packets) {
                 _msg.topic = "bundle";
@@ -39,8 +44,6 @@ module.exports = function(RED) {
         node.on("input", function(msg, send, done) {
             // When we get a Buffer
             if (Buffer.isBuffer(msg.payload)) {
-                // skip length bytes on tcp message
-                msg.payload.slice(4, msg.payload.length);
                 msg = node.decode(msg);
             // When we get an Object
             } else {


### PR DESCRIPTION
[OSC 1.0 standard](https://opensoundcontrol.stanford.edu/spec-1_0.html) says that messages sent over TCP must be prefixed with the message length, encoded as 4 bytes.


> In a stream-based protocol such as TCP, the stream should begin with an int32 giving the size of the first packet, followed by the contents of the first packet, followed by the size of the second packet, etc.

Since the OSC module does not know messages have been received by a TCP connection rather than UDP, this PR adds a TCP checkbox to tell the node module to remove and ignore the first 4 bytes, allowing it to successfully parse OSC messages.
